### PR TITLE
emit stopped event on exit

### DIFF
--- a/src/mpris.c
+++ b/src/mpris.c
@@ -27,6 +27,9 @@ static int onStart() {
 }
 
 static int onStop() {
+    debug("Emitting stop event on player exit\n");
+    emitPlaybackStatusChanged(OUTPUT_STATE_STOPPED, &mprisData);
+    
     stopServer();
 
 #if (GLIB_MAJOR_VERSION <= 2 && GLIB_MINOR_VERSION < 32)


### PR DESCRIPTION
Emit a "stopped" event on exit to clear player's status from window manager taskbar.

Fixes #12